### PR TITLE
move dependencies to dev/peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,13 @@
     "url": "https://github.com/JGLTechnologies/precise-memory-rate-limit/issues"
   },
   "homepage": "https://github.com/JGLTechnologies/precise-memory-rate-limit",
-  "dependencies": {
+  "devDependencies": {
     "express": "^4.18.1",
     "express-rate-limit": "^6.5.1",
     "tsc": "^2.0.4",
     "typescript": "^4.7.4"
-  }
+  },
+  "peerDependencies": {
+		"express-rate-limit": ">=6"
+	}
 }


### PR DESCRIPTION
None of the dependencies are actually required at runtime, and I think that including `tsc` as a dependency is the root cause of https://github.com/nfriedly/express-rate-limit/discussions/324#discussioncomment-3587237

(Note, I'm just doing this in the browser, so you probably want to give it a quick test before merging.)